### PR TITLE
商品編集ページ『画像・カテゴリ』

### DIFF
--- a/app/assets/javascripts/items/form_category_select.js
+++ b/app/assets/javascripts/items/form_category_select.js
@@ -38,8 +38,6 @@ $(document).on("change","#parent-category", function() {
     .done(function(children) {
       $("#children-category").empty();
       $("#grandchildren-category").empty();
-      $('.size_area').val('');
-      $('#size_area').css('display', 'none');
       let insertHTML = '';
       children.forEach(function(child) {
         insertHTML += appendOption(child);
@@ -52,8 +50,6 @@ $(document).on("change","#parent-category", function() {
   }else{
     $("#children-category").empty();
     $("#grandchildren-category").empty();
-    $('.size_area').val('');
-    $('#size_area').css('display', 'none');
   }
 });
 
@@ -71,8 +67,6 @@ $(document).on('change', '#children-form', function() {
     .done(function(grandchildren) {
       if (grandchildren.length != 0) {
         $("#grandchildren-category").empty();
-        $('.size_area').val('');
-        $('.size_area').css('display', 'none');
         let insertHTML = '';
         grandchildren.forEach(function(grandchild) {
           insertHTML += appendOption(grandchild);
@@ -84,19 +78,35 @@ $(document).on('change', '#children-form', function() {
       alert('error:孫カテゴリーの取得に失敗');
     })
   }else{
-    $("#grandchildren-category").empty();
-    $('.size_area').val('');
-    $('#size_area').css('display', 'none');      
+    $("#grandchildren-category").empty();   
   }
 });
 
-$(document).on('change', '#grandchildren-form', function() {
-  let grandchildId = $('#grandchildren-category option:selected').data('category');
-  if (grandchildId != "") {
-    $('.size_area').val('');
-    $('#size_area').css('display', 'block');
-  } else {
-    $('.size_area').val('');
-    $('#size_area').css('display', 'none');
+$(document).on("change","#edit-children-form", function() {
+  let childId =  $("#edit-children-form").val();
+  if (childId != "") {
+    $.ajax( {
+      type: 'GET',
+      url: 'get_category_grandchildren',
+      data: {
+         child_id: childId 
+        },
+      datatype: 'json'
+    })
+    .done(function(grandchildren) {
+      if (grandchildren.length != 0) {
+        $("#grandchildren-category").empty();
+        let insertHTML = '';
+        grandchildren.forEach(function(grandchild) {
+          insertHTML += appendOption(grandchild);
+        });
+        appendGrandchildrenBox(insertHTML);
+      }
+    })
+    .fail(function() {
+      alert('error:孫カテゴリーの取得に失敗');
+    })
+  }else{
+    $("#grandchildren-category").empty();   
   }
 });

--- a/app/assets/javascripts/items/form_category_select.js
+++ b/app/assets/javascripts/items/form_category_select.js
@@ -7,7 +7,7 @@ function appendOption(category) {
 function appendChildrenBox(insertHTML) {
   let childSelectHtml = '';
   childSelectHtml = 
-    `<select class="category_form" id="children-form">
+    `<select class="category_form required" id="children-form">
        <option value="" data-category="" >選択してください</option>
        ${insertHTML}
       </select>`;
@@ -17,7 +17,7 @@ function appendChildrenBox(insertHTML) {
 function appendGrandchildrenBox(insertHTML) {
   let grandchildSelectHtml = '';
   grandchildSelectHtml = 
-    `<select class="category_form" id="grandchildren-form" name="item[category_id]">
+    `<select class="category_form required" id="grandchildren-form" name="item[category_id]">
        <option value="" data-category="" >選択してください</option>
        ${insertHTML}
       </select>`;

--- a/app/assets/javascripts/items/form_imaage.js
+++ b/app/assets/javascripts/items/form_imaage.js
@@ -1,9 +1,20 @@
 $(document).on('turbolinks:load', ()=>{
   const buildFileField = (index)=>{
-    const html = `<div data-index="${index}" class="image_file">
+    const html = `<div data-index="${index}" class="image_file" id="image_file_${index}">
                     <label for="item_images_attributes_${index}_image">
                       <div class="image_file__field" id="image_file_${index}"></div>
                       <input class="image_form" type=file
+                      name="item[images_attributes][${index}][image]"
+                      id="item_images_attributes_${index}_image">
+                    </label>
+                  </div>`;
+    return html;
+  }
+  const buildEditFileField = (index)=>{
+    const html = `<div data-index="${index}" class="image_file" id="image_file_${index}">
+                    <label for="item_images_attributes_${index}_image">
+                      <div class="image_file__field" id="image_file_${index}"></div>
+                      <input class="image_edit_form" type=file
                       name="item[images_attributes][${index}][image]"
                       id="item_images_attributes_${index}_image">
                     </label>
@@ -23,6 +34,11 @@ $(document).on('turbolinks:load', ()=>{
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
   lastIndex = $('.image_form:last').data('index');
   fileIndex.splice(0, lastIndex);
+  let fileEditIndex = [11,12,13,14,15,16,17,18,19,20]
+  lastEditIndex = $('.image_view:last').data('index');
+  fileEditIndex.splice(0, lastEditIndex);
+
+  $('.hidden-destroy').hide();
 
   $('.image_box').on('change', '.image_form', function(e){
     const targetIndex = $(this).parent().parent().data('index');
@@ -38,9 +54,26 @@ $(document).on('turbolinks:load', ()=>{
       fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
     }
   });
-  $('.image_box').on('click', '.image_remove', function() {
+
+  $('.image_box').on('change', '.image_edit_form', function(e){
+    const targetIndex = $(this).parent().parent().data('index');
+    const file = e.target.files[0];
+    const blobUrl = window.URL.createObjectURL(file);
+    if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
+      img.setAttribute('src', blobUrl);
+    } else {
+      $('#previews').append(buildImg(targetIndex, blobUrl));
+      $('.image_file').css('display', 'none');
+      $('.image_box').append(buildEditFileField(fileEditIndex[0] + 1));
+      console.log(fileEditIndex[0]);
+      fileEditIndex.shift();
+      fileEditIndex.push(fileEditIndex[fileEditIndex.length - 1] + 1);
+    }
+  });
+
+  $('#previews').on('click', '.image_remove', function() {
     const targetIndex = $(this).parent().data('index');
-    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
+    const hiddenCheck = $(`#item_images_attributes_${targetIndex}__destroy`);
     if (hiddenCheck) hiddenCheck.prop('checked', true);
     $(this).parent().remove();
     console.log($(this).parent());

--- a/app/assets/javascripts/items/form_submit.js
+++ b/app/assets/javascripts/items/form_submit.js
@@ -1,0 +1,5 @@
+// $(document).on('turbolinks:load', ()=>{
+//   $('#new_item_form').change(function(){
+//     if
+//   })
+// });

--- a/app/assets/javascripts/items/form_submit.js
+++ b/app/assets/javascripts/items/form_submit.js
@@ -1,5 +1,19 @@
-// $(document).on('turbolinks:load', ()=>{
-//   $('#new_item_form').change(function(){
-//     if
-//   })
-// });
+$(document).on('turbolinks:load', ()=> {
+  $(function() {
+    $('.submit_btn').prop("disabled", true);
+    $('.required').change(function() {
+      let flag = true
+      $('.required').each(function(e){
+        if($('.required').eq(e).val() === "") {
+          flag = false;
+        }
+      });
+      if (flag) {
+        $('.submit_btn').prop("disabled", false);
+      }
+      else {
+        $('.submit_btn').prop("disabled", true);
+      }
+    });
+  });
+});

--- a/app/assets/stylesheets/items/_items_form.scss
+++ b/app/assets/stylesheets/items/_items_form.scss
@@ -73,7 +73,7 @@
     #previews {
       display: flex;
       .image_view {
-        width: 123px;
+        width: 124px;
         height: 148px;
         margin-right: 1px;
         background-color: #f5f5f5;
@@ -96,7 +96,7 @@
       height: 80px;
       }
     }
-
+    
   .image_file {
     width: 100%;
     height: 150px;
@@ -110,10 +110,18 @@
       border: 1px dashed #cccccc;
     }
   }
-    
-    .image_form {
-      display: none;
-    }
+  .image_form {
+    display: none;
+  }
+  .image_edit_form {
+    display: none;
+  }
+  input[type=checkbox] {
+    display: none;
+  }
+  #image_file_5 {
+    display: none;
+  }
   }
   .item_info {
     width: 620px;

--- a/app/assets/stylesheets/items/_items_form.scss
+++ b/app/assets/stylesheets/items/_items_form.scss
@@ -181,7 +181,27 @@
     height: 164px;
     width: 360px;
     margin: 0 170px;
+    .submit_btn[disabled] {
+      height: 48px;
+      width: 360px;
+      background-color: #5f5f5f;
+      color: #ffffff;
+      font-size: 17px;
+      padding: 0 24px;
+      margin: 0 auto;
+      border: none;
+    }
     .submit_btn {
+      height: 48px;
+      width: 360px;
+      background-color: #3ccace;
+      color: #ffffff;
+      font-size: 17px;
+      padding: 0 24px;
+      margin: 0 auto;
+      border: none;
+    }
+    .submit_edit_btn {
       height: 48px;
       width: 360px;
       background-color: #3ccace;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,7 +33,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to @item, notice: 'Item was successfully created.'
     else
-      render :new
+      redirect_to new_item_path
     end
   end
 
@@ -56,14 +56,10 @@ class ItemsController < ApplicationController
   end
 
   def update
-    respond_to do |format|
-      if @item.update(item_params)
-        format.html { redirect_to @item, notice: '編集しました' }
-        format.json { render :show, status: :ok, location: @item }
-      else
-        format.html { render :edit }
-        format.json { render json: @item.errors, status: :unprocessable_entity }
-      end
+    if @item.update(item_params)
+      redirect_to @item, notice: '編集しました'
+    else
+      redirect_to edit_item_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -47,10 +47,12 @@ class ItemsController < ApplicationController
   
   def edit
     @images = Image.where(item_id: params[:id])
-    @category = Category.where(params[:category_id])
+    @category = Category.find(params[:id])
     @grandchild_category = @item.category
     @child_category = @grandchild_category.parent
     @parent_category = @child_category.parent
+    @category_children = @item.category.parent.parent.children
+    @category_grandchildren = @item.category.parent.children
   end
 
   def update

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -2,7 +2,7 @@
   .new_item_header
     =link_to image_tag("logo.png"), "/"
   .new_item_main
-    =form_with model: @item, local: true do |f|
+    =form_with model: @item,id: 'item_form', local: true do |f|
       .frame
         .area
           .title
@@ -12,18 +12,19 @@
             #previews
               -if @item.persisted?
                 -@item.images.each_with_index do |src, i|
-                  =image_tag src.image.url, {data: {index: i}}
-            =f.fields_for :images do |src|
-              .image_file{data:{index: src.index}}
+                  .image_view{data:{index: i}}
+                    .image_src
+                      =image_tag src.image.url, {data: {index: i}}
+                    .image_remove 削除
+              =f.fields_for :images do |src|
                 =src.file_field :image, class: 'image_form'
-                %span.image_remove 削除
-              -if @item.persisted?
-                =src.check_box :_destroy, {data:{ index: src.index }}, class: 'hidden_destroy'
+                -if @item.persisted?
+                  =src.check_box :_destroy, {data:{ index: src.index }}, :class => 'hidden_destroy'
             -if @item.persisted?
               .image_file{data:{index: @item.images.count}}
-                =file_field_tag :image,  name: "item[images_attributes][#{@item.images.count}][image]", class: 'image_form'
-                %span.image_remove 削除
-            
+                =f.label :image do
+                  .image_file__field
+                  =f.file_field :image,  name: "item[images_attributes][#{@item.images.count}][image]", class: 'image_edit_form'
       .frame
         .item_info
           .area.name_area
@@ -53,23 +54,11 @@
               %li
                 =@grandchild_category.name
             .select_form#parent-category
-              =f.select :category_id, options_for_select( @category_parent_array.map{|c| [c[:name], c[:id]]}), {include_blank: "選択してください"}, { class: "category_form", id: "parent-form"}
+              =f.select :category_id, options_for_select( @category_parent_array.map{|c| [c[:name], c[:id]]}, @parent_category.id ), {include_blank: "選択してください"}, { class: "category_form", id: "parent-form"}
             .select_form#children-category
-              =f.select :category_id, Category.all
+              =f.select :category_id, options_for_select( @category_children.map{|c| [c[:name], c[:id]]}, @child_category.id ), {include_blank: "選択してください"}, { class: "category_form", id: "edit-children-form"}
             .select_form#grandchildren-category
-              =f.select :category_id, Category.all
-          -# .area#size_area
-          -#   .size_title.title
-          -#     =f.label :size_id, 'サイズ'
-          -#     %span.style_need 必須
-          -#   .select_form#size-form
-          -#     =f.select :size_id, [["選択してください",""],["XXS以下",1],["XS",2],["S",3],["M",4],["L",5],["XL",6],["XXL",7]]
-          -# .brand_area.area
-          -#   .brand_title.title
-          -#     =f.label :brand, 'ブランド'
-          -#     %span.style_any 任意
-          -#   .brand-form.select_form
-          -#     =f.collection_select :brand_id, Brand.all, :id,:name, {include_blank: "選択してください"}
+              =f.select :category_id, options_for_select( @category_grandchildren.map{|c| [c[:name], c[:id]]}, @grandchild_category.id ), {include_blank: "選択してください"}, { class: "category_form", id: "grandchildren-form"}
           .status_area.area
             .status_title.title
               =f.label :status, '商品の状態'

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -54,11 +54,11 @@
               %li
                 =@grandchild_category.name
             .select_form#parent-category
-              =f.select :category_id, options_for_select( @category_parent_array.map{|c| [c[:name], c[:id]]}, @parent_category.id ), {include_blank: "選択してください"}, { class: "category_form", id: "parent-form"}
+              =f.select :category_id, options_for_select( @category_parent_array.map{|c| [c[:name], c[:id]]}, @parent_category.id ), { class: "category_form", id: "parent-form"}
             .select_form#children-category
-              =f.select :category_id, options_for_select( @category_children.map{|c| [c[:name], c[:id]]}, @child_category.id ), {include_blank: "選択してください"}, { class: "category_form", id: "edit-children-form"}
+              =f.select :category_id, options_for_select( @category_children.map{|c| [c[:name], c[:id]]}, @child_category.id ), { class: "category_form", id: "edit-children-form"}
             .select_form#grandchildren-category
-              =f.select :category_id, options_for_select( @category_grandchildren.map{|c| [c[:name], c[:id]]}, @grandchild_category.id ), {include_blank: "選択してください"}, { class: "category_form", id: "grandchildren-form"}
+              =f.select :category_id, options_for_select( @category_grandchildren.map{|c| [c[:name], c[:id]]}, @grandchild_category.id ), { class: "category_form", id: "grandchildren-form"}
           .status_area.area
             .status_title.title
               =f.label :status, '商品の状態'
@@ -93,6 +93,6 @@
           %input{type: "number", style: "display: none", id: "price"}
           .right_bar_2
       .submit_frame
-        =f.submit '編集を保存する',class: 'submit_btn'
+        =f.submit '編集を保存する',class: 'submit_edit_btn'
         .back_home
           =link_to  "もどる", users_path

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -19,7 +19,7 @@
               .image_file{data:{index: src.index}}
                 =src.label :image do
                   .image_file__field
-                  =src.file_field :image, class: 'image_form'
+                  =src.file_field :image, class: 'image_form required'
               -if @item.persisted?
                 =src.check_box :_destroy, {data:{ index: src.index }}, class: 'hidden_destroy'
             -if @item.persisted?
@@ -32,12 +32,12 @@
             .title
               =f.label :name, '商品名'
               %span.style_need 必須
-            =f.text_field :name, class: 'name_form', placeholder: "40字まで"
+            =f.text_field :name, class: 'name_form required', placeholder: "40字まで"
           .description_area.area
             .description_title.title
               =f.label :description, '商品説明'
               %span.style_need 必須
-            =f.text_area :text, class: "description_form", placeholder: "色・素材・重さ・定価・注意点などを記載しましょう（1000文字まで）例:先月に5,400円で購入したセーターです。着用回数は5回未満です。素材はカシミヤなので着心地がいいです。" 
+            =f.text_area :text, class: 'description_form required', placeholder: "色・素材・重さ・定価・注意点などを記載しましょう（1000文字まで）例:先月に5,400円で購入したセーターです。着用回数は5回未満です。素材はカシミヤなので着心地がいいです。" 
       .frame
         .item_data
           .area#category_area
@@ -45,21 +45,9 @@
               =f.label :category, 'カテゴリー'
               %span.style_need 必須
             .select_form#parent-category
-              =f.select :category_id, options_for_select( @category_parent_array.map{|c| [c[:name], c[:id]]}), {include_blank: "選択してください"}, { class: "category_form", id: "parent-form"}
+              =f.select :category_id, options_for_select( @category_parent_array.map{|c| [c[:name], c[:id]]}), {include_blank: "選択してください"}, { class: "category_form required", id: "parent-form"}
             .select_form#children-category
             .select_form#grandchildren-category
-          -# .area#size_area
-          -#   .size_title.title
-          -#     =f.label :size_id, 'サイズ'
-          -#     %span.style_need 必須
-          -#   .select_form#size-form
-          -#     =f.select :size_id, [["選択してください",""],["XXS以下",1],["XS",2],["S",3],["M",4],["L",5],["XL",6],["XXL",7]]
-          -# .brand_area.area
-          -#   .brand_title.title
-          -#     =f.label :brand, 'ブランド'
-          -#     %span.style_any 任意
-          -#   .brand-form.select_form
-          -#     =f.collection_select :brand_id, Brand.all, :id,:name, {include_blank: "選択してください"}
           .status_area.area
             .status_title.title
               =f.label :status, '商品の状態'
@@ -78,13 +66,13 @@
             =f.label :shipping_date, '発送までの日数'
             %span.style_need 必須
           .delivery_day-form.select_form
-            =f.select :shipping_date, [["選択してください","0"],["1日〜2日","1日〜2日"],["3日〜4日","3日〜4日"],["5日〜6日","5日〜6日"],["7日以降","7日以降"]]
+            =f.select :shipping_date, [["選択してください",""],["1日〜2日","1日〜2日"],["3日〜4日","3日〜4日"],["5日〜6日","5日〜6日"],["7日以降","7日以降"]]
       .price_frame
         .price_area.area
           .price_title.title
             =f.label :price, '販売価格'
             %space.style_need 必須
-          =f.number_field :price, class: 'price_form', placeholder: "¥300 ~ 9,999,999"
+          =f.number_field :price, class: 'price_form required', placeholder: "¥300 ~ 9,999,999"
         .item_price-fee
           %p 販売手数料(10%)
           .right_bar

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -2,7 +2,7 @@
   .new_item_header
     =link_to image_tag("logo.png"), "/"
   .new_item_main
-    =form_with model: @item, local: true do |f|
+    =form_with model: @item, id: 'item_form', local: true do |f|
       .frame
         .area
           .title
@@ -26,7 +26,6 @@
               .image_file{data:{index: @item.images.count}}
                 =file_field_tag :image,  name: "item[images_attributes][#{@item.images.count}][image]", class: 'image_form'
                 %span.image_remove 削除
-
       .frame
         .item_info
           .area.name_area

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,9 +882,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.0.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.23.tgz#676fa0883450ed9da0bb24156213636290892806"
-  integrity sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==
+  version "14.0.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.24.tgz#b0f86f58564fa02a28b68f8b55d4cdec42e3b9d6"
+  integrity sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1714,9 +1714,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097:
-  version "1.0.30001102"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001102.tgz#3275e7a8d09548f955f665e532df88de0b63741a"
-  integrity sha512-fOjqRmHjRXv1H1YD6QVLb96iKqnu17TjcLSaX64TwhGYed0P1E1CCWZ9OujbbK4Z/7zax7zAzvQidzdtjx8RcA==
+  version "1.0.30001104"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001104.tgz#4e3d5b3b1dd3c3529f10cb7f519c62ba3e579f5d"
+  integrity sha512-pkpCg7dmI/a7WcqM2yfdOiT4Xx5tzyoHAXWsX5/HxZ3TemwDZs0QXdqbE0UPLPVy/7BeK7693YfzfRYfu1YVpg==
 
 case-sensitive-paths-webpack-plugin@^2.2.0:
   version "2.3.0"
@@ -2557,9 +2557,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.488:
-  version "1.3.500"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.500.tgz#ac082dd2279251b14f1a7f6af6fd16655cf3eb7b"
-  integrity sha512-Zz8BZh4Ssb/rZBaicqpi+GOQ0uu3y+24+MxBLCk0UYt8EGoZRP4cYzYHHwXGZfrSbCU4VDjbWN+Tg+TPgOUX6Q==
+  version "1.3.502"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.502.tgz#6a55e993ef60a01fbdc2152ef5e47ee00c885c98"
+  integrity sha512-TIeXOaHAvfP7FemGUtAJxStmOc1YFGWFNqdey/4Nk41L9b1nMmDVDGNMIWhZJvOfJxix6Cv5FGEnBK+yvw3UTg==
 
 elliptic@^6.0.0, elliptic@^6.5.2:
   version "6.5.3"
@@ -5068,9 +5068,9 @@ pnp-webpack-plugin@^1.5.0:
     ts-pnp "^1.1.6"
 
 portfinder@^1.0.26:
-  version "1.0.26"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.26.tgz#475658d56ca30bed72ac7f1378ed350bd1b64e70"
-  integrity sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==
+  version "1.0.27"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.27.tgz#a41333c116b5e5f3d380f9745ac2f35084c4c758"
+  integrity sha512-bJ3U3MThKnyJ9Dx1Idtm5pQmxXqw08+XOHhi/Lie8OF1OlhVaBFhsntAIhkZYjfDcCzszSr0w1yCbccThhzgxQ==
   dependencies:
     async "^2.6.2"
     debug "^3.1.1"


### PR DESCRIPTION
# what

商品編集機能の画像・カテゴリの実装
JSによる動的な表示

# why

出品後の商品変更のため

# other

- 何も変更せず保存しても画像、カテゴリはそのままの状態です。
https://gyazo.com/44f2c88dabde38ce736706314b0b2f01
- 画像のviewを消したら_destroyのcheck_boxにチェックが入り保存時に削除されます。
https://gyazo.com/9ac80f8abddbf4bcd562a026158d4c9e
（間に合わなかったので詳細ページ画像貼ります）
https://gyazo.com/0b5d690cf7d024bfb2400c14ba5e0639
- カテゴリ初期値の表示と変更に連動した子・孫カテゴリの呼び出し
https://gyazo.com/25689496f8a3b2067feed90586d6f003

